### PR TITLE
Verify SNP AttestationReport without OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,10 @@ bincode = "^1.3"
 hex = "0.4.3"
 libc = "0.2.147"
 lazy_static = "1.4.0"
+p384 = "0.13.0"
+rsa = "0.9.2"
+sha2 = "0.10.8"
+x509-cert = "0.2.4"
 
 [dev-dependencies]
 kvm-ioctls = ">=0.12"

--- a/src/certs/snp/builtin/genoa/mod.rs
+++ b/src/certs/snp/builtin/genoa/mod.rs
@@ -10,12 +10,12 @@ pub const ASK: &[u8] = include_bytes!("ask.pem");
 
 /// Get the Genoa ARK Certificate.
 pub fn ark() -> Result<Certificate> {
-    Ok(Certificate::from(X509::from_pem(ARK)?))
+    Certificate::from_pem(ARK)
 }
 
 /// Get the Genoa ASK Certificate.
 pub fn ask() -> Result<Certificate> {
-    Ok(Certificate::from(X509::from_pem(ASK)?))
+    Certificate::from_pem(ASK)
 }
 
 mod tests {

--- a/src/certs/snp/builtin/milan/mod.rs
+++ b/src/certs/snp/builtin/milan/mod.rs
@@ -10,12 +10,12 @@ pub const ASK: &[u8] = include_bytes!("ask.pem");
 
 /// Get the Milan ARK Certificate.
 pub fn ark() -> Result<Certificate> {
-    Ok(Certificate::from(X509::from_pem(ARK)?))
+    Certificate::from_pem(ARK)
 }
 
 /// Get the Milan ASK Certificate.
 pub fn ask() -> Result<Certificate> {
-    Ok(Certificate::from(X509::from_pem(ASK)?))
+    Certificate::from_pem(ASK)
 }
 
 mod tests {

--- a/src/certs/snp/cert.rs
+++ b/src/certs/snp/cert.rs
@@ -2,78 +2,152 @@
 
 use super::*;
 
+#[cfg(feature = "openssl")]
 use openssl::pkey::{PKey, Public};
+
+use der::{referenced::OwnedToRef, Decode, DecodePem, Encode};
+use rsa::signature; // re-export of signature crate
+use signature::Verifier;
+use spki::ObjectIdentifier;
+use std::convert::TryFrom;
+use std::io;
+use std::io::ErrorKind;
+use x509_cert::der; // re-export of der crate
+use x509_cert::spki; // re-export of spki crate
 
 /// Structures/interfaces for SEV-SNP certificates.
 
 #[derive(Clone, Debug)]
-pub struct Certificate(X509);
+pub struct Certificate(x509_cert::Certificate);
 
 /// Wrap an X509 struct into a Certificate.
-impl From<X509> for Certificate {
-    fn from(x509: X509) -> Self {
-        Self(x509)
+#[cfg(feature = "openssl")]
+impl TryFrom<X509> for Certificate {
+    type Error = io::Error;
+
+    fn try_from(x509: X509) -> std::result::Result<Self, Self::Error> {
+        Self::from_der(&x509.to_der()?)
     }
 }
 
 /// Unwrap the underlying X509 struct from a Certificate.
-impl From<Certificate> for X509 {
-    fn from(cert: Certificate) -> Self {
-        cert.0
+#[cfg(feature = "openssl")]
+impl TryFrom<Certificate> for X509 {
+    type Error = io::Error;
+
+    fn try_from(cert: Certificate) -> std::result::Result<Self, Self::Error> {
+        Self::try_from(&cert)
     }
 }
 
 /// Clone the underlying X509 structure from a reference to a Certificate.
-impl From<&Certificate> for X509 {
-    fn from(cert: &Certificate) -> Self {
-        cert.0.clone()
+#[cfg(feature = "openssl")]
+impl TryFrom<&Certificate> for X509 {
+    type Error = io::Error;
+
+    fn try_from(cert: &Certificate) -> std::result::Result<Self, Self::Error> {
+        X509::from_der(&cert.to_der()?).map_err(|e| {
+            io::Error::new(
+                ErrorKind::InvalidData,
+                format!("failed to create X509 from DER: {e:?}"),
+            )
+        })
     }
 }
+
+const RSA_SSA_PSS_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.10");
 
 /// Verify if the public key of one Certificate signs another Certificate.
 impl Verifiable for (&Certificate, &Certificate) {
     type Output = ();
 
     fn verify(self) -> Result<Self::Output> {
-        let signer: X509 = self.0.into();
-        let signee: X509 = self.1.into();
+        let signer = &self.0 .0;
+        let signee = &self.1 .0;
 
-        let key: PKey<Public> = signer.public_key()?;
-        let signed = signee.verify(&key)?;
-
-        match signed {
-            true => Ok(()),
-            false => Err(Error::new(
-                ErrorKind::Other,
-                "Signer certificate does not sign signee certificate",
-            )),
+        if signee.signature_algorithm.oid != RSA_SSA_PSS_OID {
+            return Err(io_error_other(format!(
+                "unsupported signature algorithm: {:?}",
+                signee.signature_algorithm
+            )));
         }
+
+        let rsa_verifying_key = {
+            let signer_spki_ref = signer
+                .tbs_certificate
+                .subject_public_key_info
+                .owned_to_ref();
+            let signer_pubkey_rsa = rsa::RsaPublicKey::try_from(signer_spki_ref)
+                .map_err(|e| io_error_other(format!("invalid RSA public key: {e:?}")))?;
+            rsa::pss::VerifyingKey::<sha2::Sha384>::new(signer_pubkey_rsa)
+        };
+
+        let message = signee.tbs_certificate.to_der().map_err(|e| {
+            io_error_other(format!("failed to encode tbs_certificate as DER: {e:?}"))
+        })?;
+
+        let rsa_signature = rsa::pss::Signature::try_from(signee.signature.raw_bytes())
+            .map_err(|e| io_error_other(format!("invalid RSA signature: {e:?}")))?;
+
+        rsa_verifying_key
+            .verify(&message, &rsa_signature)
+            .map_err(|e| {
+                io_error_other(format!(
+                    "Signer certificate does not RSA sign signee certificate: {e}"
+                ))
+            })
     }
 }
 
 impl Certificate {
     /// Create a Certificate from a PEM-encoded X509 structure.
     pub fn from_pem(pem: &[u8]) -> Result<Self> {
-        Ok(Self(X509::from_pem(pem)?))
+        let cert = x509_cert::Certificate::from_pem(pem)
+            .map_err(|e| io::Error::new(ErrorKind::InvalidData, format!("invalid PEM: {}", e)))?;
+        Ok(Self(cert))
     }
 
     /// Serialize a Certificate struct to PEM.
     pub fn to_pem(&self) -> Result<Vec<u8>> {
-        Ok(self.0.to_pem()?)
+        use der::EncodePem;
+        Ok(self
+            .0
+            .to_pem(x509_cert::der::pem::LineEnding::default())
+            .map_err(|e| io_error_other(format!("PEM-encoding failed: {}", e)))?
+            .into_bytes())
     }
 
     /// Create a Certificate from a DER-encoded X509 structure.
     pub fn from_der(der: &[u8]) -> Result<Self> {
-        Ok(Self(X509::from_der(der)?))
+        let cert = x509_cert::Certificate::from_der(der)
+            .map_err(|e| io::Error::new(ErrorKind::InvalidData, format!("invalid DER: {}", e)))?;
+
+        Ok(Self(cert))
     }
 
     /// Serialize a Certificate struct to DER.
     pub fn to_der(&self) -> Result<Vec<u8>> {
-        Ok(self.0.to_der()?)
+        self.0
+            .to_der()
+            .map_err(|e| io_error_other(format!("DER-encoding failed: {e:?}")))
     }
 
+    /// Retrieve the public key in SEC1 encoding.
+    pub fn public_key_sec1(&self) -> &[u8] {
+        self.0
+            .tbs_certificate
+            .subject_public_key_info
+            .subject_public_key
+            .raw_bytes()
+    }
+
+    #[cfg(feature = "openssl")]
     /// Retrieve the underlying X509 public key for a Certificate.
     pub fn public_key(&self) -> Result<PKey<Public>> {
-        Ok(self.0.public_key()?)
+        Ok(X509::try_from(self)?.public_key()?)
     }
+}
+
+fn io_error_other<S: Into<String>>(error: S) -> io::Error {
+    io::Error::new(ErrorKind::Other, error.into())
 }

--- a/src/certs/snp/ecdsa/mod.rs
+++ b/src/certs/snp/ecdsa/mod.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "openssl")]
 use super::*;
 
 use crate::util::hexdump;
@@ -8,7 +7,6 @@ use crate::util::hexdump;
 #[cfg(feature = "openssl")]
 use crate::certs::snp::{AsLeBytes, FromLe};
 
-#[cfg(feature = "openssl")]
 use std::convert::TryFrom;
 
 use serde::{Deserialize, Serialize};
@@ -106,6 +104,28 @@ impl TryFrom<&Signature> for ecdsa::EcdsaSig {
         let r = bn::BigNum::from_le(&value.r)?;
         let s = bn::BigNum::from_le(&value.s)?;
         Ok(ecdsa::EcdsaSig::from_private_components(r, s)?)
+    }
+}
+
+impl TryFrom<&Signature> for p384::ecdsa::Signature {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(signature: &Signature) -> Result<Self> {
+        let r_big_endian: Vec<u8> = signature.r.iter().copied().take(48).rev().collect();
+        let s_big_endian: Vec<u8> = signature.s.iter().copied().take(48).rev().collect();
+
+        use p384::elliptic_curve::generic_array::GenericArray;
+        p384::ecdsa::Signature::from_scalars(
+            GenericArray::clone_from_slice(&r_big_endian),
+            GenericArray::clone_from_slice(&s_big_endian),
+        )
+        .map_err(|e| {
+            Error::new(
+                ErrorKind::Other,
+                format!("failed to deserialize signature from scalars: {e:?}"),
+            )
+        })
     }
 }
 

--- a/src/certs/snp/mod.rs
+++ b/src/certs/snp/mod.rs
@@ -3,29 +3,22 @@
 /// ECDSA signatures.
 pub mod ecdsa;
 
-#[cfg(feature = "openssl")]
 /// Certificate Authority (CA) certificates.
 pub mod ca;
 
-#[cfg(feature = "openssl")]
 /// Built-in certificates for Milan and Genoa machines.
 pub mod builtin;
 
-#[cfg(feature = "openssl")]
 mod cert;
 
-#[cfg(feature = "openssl")]
 mod chain;
 
-#[cfg(feature = "openssl")]
 pub use cert::Certificate;
 
-#[cfg(feature = "openssl")]
 pub use chain::Chain;
 
 use std::io::Result;
 
-#[cfg(feature = "openssl")]
 use std::io::{Error, ErrorKind};
 
 #[cfg(feature = "openssl")]
@@ -35,7 +28,6 @@ use openssl::x509::X509;
 #[allow(dead_code)]
 struct Body;
 
-#[cfg(feature = "openssl")]
 /// An interface for types that may contain entities such as
 /// signatures that must be verified.
 pub trait Verifiable {

--- a/tests/certs.rs
+++ b/tests/certs.rs
@@ -24,16 +24,12 @@ mod sev {
 
 #[cfg(feature = "snp")]
 mod snp {
-    #[cfg(feature = "openssl")]
     use sev::certs::snp::{builtin::milan, ca, Certificate, Chain, Verifiable};
 
-    #[cfg(feature = "openssl")]
     const TEST_MILAN_VCEK_DER: &[u8] = include_bytes!("certs_data/vcek_milan.der");
 
-    #[cfg(feature = "openssl")]
     const TEST_MILAN_ATTESTATION_REPORT: &[u8] = include_bytes!("certs_data/report_milan.hex");
 
-    #[cfg(feature = "openssl")]
     #[test]
     fn milan_chain() {
         let ark = milan::ark().unwrap();
@@ -47,7 +43,6 @@ mod snp {
         chain.verify().unwrap();
     }
 
-    #[cfg(feature = "openssl")]
     #[test]
     fn milan_report() {
         use sev::firmware::guest::AttestationReport;


### PR DESCRIPTION
Refactors the code so that an SNP `AttestationReport` can be verified without the `openssl` feature.

#### Notes
* `cargo test` and `cargo test --features=openssl` and `cargo clippy` pass (on Ubuntu 22.04.1 LTS with AMD EPYC-Milan).
* Switches the internal representation of `snp::Certificate` from `openssl::x509::X509` to `x509_cert::Certificate`.
* The intent of the change is to be as minimally invasive as possible.. Retains the current API wherever possible. The following lists APIs that could not (easily) be retained and their substitution. Note, however, that it is unclear if the following three `impl`s are even needed: they are kept to be somewhat backwards-compatible, but it may actually be cleaner to just remove those entirely.
  * `impl From<X509> for Certificate` --> `impl TryFrom<X509> for Certificate`
  * `impl From<Certificate> for X509` --> `impl TryFrom<Certificate> for X509`
  * `impl From<&Certificate> for X509` --> `impl TryFrom<&Certificate> for X509`