### PR TITLE
Add public getters for SNP ECDSA signature

### DIFF
--- a/src/certs/snp/ecdsa/mod.rs
+++ b/src/certs/snp/ecdsa/mod.rs
@@ -32,6 +32,18 @@ pub struct Signature {
     _reserved: [u8; 512 - R_S_SIZE],
 }
 
+impl Signature {
+    /// Returns the signatures `r` component
+    pub fn r(&self) -> &[u8; 72] {
+        &self.r
+    }
+
+    /// Returns the signatures `s` component
+    pub fn s(&self) -> &[u8; 72] {
+        &self.s
+    }
+}
+
 impl std::fmt::Debug for Signature {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(


### PR DESCRIPTION
Adds public getters to the (also public) `crate::certs::snp::ecdsa::Signature`.

This allows for manual verification of an `AttestationReport`'s signature outside of the crate, for example without the need for OpenSSL (with the `openssl` feature).